### PR TITLE
Fix of pgtable naming convention issue

### DIFF
--- a/bin/daemon.js
+++ b/bin/daemon.js
@@ -107,14 +107,16 @@ function findFeeds(find_once) {
             process.exit();
         } else {
             var pgtable;
+            var couchdb;
 
             console.log("FINDER: " + result.rows.length + ' dbs to check found');
             for (var i = 0; i < result.rows.length; i++) {
-                pgtable = result.rows[i].pgtable;
+                couchdb = result.rows[i].pgtable;
+                pgtable = couchdb.replace(/\-/g,"_");
+
                 if (PostgresCouchContainer[pgtable] === undefined) {
                     pgtableCheck(pgtable);
 
-                    couchdb = pgtable;
                     PostgresCouchContainer[pgtable] = new PostgresCouchDB(pgclient, {
                         couchdb: {
                             url: daemon_settings["couchdb"]["url"],

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ function PostgresCouchDB(pgclient, options) {
 
         var opts = set_options(options);
         var events = new EventEmitter();
-	
+
         var changecount = opts.couchdb.since;
         if(changecount < 0) changecount = 0;
         var previous_since = changecount;
@@ -29,13 +29,13 @@ function PostgresCouchDB(pgclient, options) {
                     password: opts.couchdb.password || process.env.COUCHDB_PASSWORD,
                     database: opts.couchdb.database || process.env.COUCHDB_DATABASE,
                     since: opts.couchdb.since || 0,
-                    pgtable: opts.couchdb.pgtable || process.env.PGTABLE
+                    pgtable: (opts.couchdb.pgtable || process.env.PGTABLE).replace(/\-/g,"_")
                 },
                 map: opts.map || null
             };
         }
         var pgtable = opts.couchdb.pgtable;
-    
+
 
         var queue = async.queue(process_change, 1);
         queue.drain = function() {
@@ -55,7 +55,7 @@ function PostgresCouchDB(pgclient, options) {
 
 	setTimeout(function() {
  	    events.emit('checkpoint', opts.couchdb.pgtable + ': Starting checkpointer');
-            checkpoint_changes(changecount)  
+            checkpoint_changes(changecount)
 	}, 1000);
 
 
@@ -67,7 +67,7 @@ function PostgresCouchDB(pgclient, options) {
 
 		if(last_changecount < changecount){
 		    //do insert into stats table here?
-		    //maybe something like (changecount - last_changecount), NOW() 
+		    //maybe something like (changecount - last_changecount), NOW()
 		    //then we only collect stats when there is a change and can assume 0 changes otherwise
 		    //can then work out changes/sec etc
 		    //at the moment not possible todo stats on what type of change
@@ -106,7 +106,7 @@ function PostgresCouchDB(pgclient, options) {
                         doc_rev_num = doc._rev.split('-')[0];
                         pg_rev_num = result.rows[0].rev.split('-')[0];
 
-                        if (doc._rev != result.rows[0].rev) {		     
+                        if (doc._rev != result.rows[0].rev) {
                                // console.log(pgtable + ": update " + doc._id + " pg_rev: " + pg_rev_num + " < doc_rev: " + doc_rev_num);
 
                                 json_doc = pgescape.literal(JSON.stringify(doc));
@@ -201,12 +201,12 @@ function PostgresCouchDB(pgclient, options) {
                 })
                 .fail(function(err) {
 
-                  if (err.code == "EPIPE") { //pg gone away - 
+                  if (err.code == "EPIPE") { //pg gone away -
                     console.error('Error EPIPE:' + opts.couchdb.pgtable + ' in change');
                     status = 'Error: EPIPE';
                     //events.emit('error', opts.couchdb.pgtable + ': EPIPE', err);
-                    stopFollowing();                    
-                  } else if (err.code == '42P01'){      
+                    stopFollowing();
+                  } else if (err.code == '42P01'){
                      console.error('Error 42P01:' + opts.couchdb.pgtable + ' in change');
                      status = 'Error: table not found in postgres datebase';
                      stopFollowing();
@@ -216,12 +216,12 @@ function PostgresCouchDB(pgclient, options) {
 //                     stopFollowing();
                 } else if (err.code == "ECONNRESET") { //pg gone away - cant catch here for some reason - try in changes.error
                     status = 'Error: ECONNRESET';
-                    stopFollowing();                    
+                    stopFollowing();
                      console.error('Error ECONNRESET:' + opts.couchdb.pgtable + ' in change');
 
                } else if (err.code == 'ECONNREFUSED') { //couchdb error
                     status = 'Error: Not connected to couch server trying to reconnect.';
-                    wait = Math.floor(Math.random() * (60000 - 10000) + 10000); //mixup wait time as could be many 
+                    wait = Math.floor(Math.random() * (60000 - 10000) + 10000); //mixup wait time as could be many
                     console.error('Error ECONNREFUSED:' + opts.couchdb.pgtable + ' in change');
                     setTimeout(function() {
                         stream.restart();
@@ -265,7 +265,7 @@ function PostgresCouchDB(pgclient, options) {
             stream.on('error', function(err) {
                 if (err.code == 'ECONNREFUSED') { //couchdb error
                     status = 'Error: Not connected to couch server trying to reconnect.';
-                    wait = Math.floor(Math.random() * (60000 - 10000) + 10000); //mixup wait time as could be many 
+                    wait = Math.floor(Math.random() * (60000 - 10000) + 10000); //mixup wait time as could be many
                     events.emit('error', opts.couchdb.pgtable + ': Error connection refused. Sleeping for: ' + Math.floor(wait / 1000) + ' seconds', err);
                     setTimeout(function() {
                         stream.restart();
@@ -299,7 +299,7 @@ function PostgresCouchDB(pgclient, options) {
             alive = false;
         }
 
-	
+
 
 
 


### PR DESCRIPTION
Postgresql table names can not be with 'dash' symbols, with underscores only.
    
For example:
CouchDB database can have 'dash' symbols in name.
    
Like:
```
company-slug-100_development
```
Postgresql table can't be created with same name.
    
Solution is to_underscore pgtable names in bin/daemon.js and lib/index.js.